### PR TITLE
2020 Year in review

### DIFF
--- a/news/year-in-review-2020.md
+++ b/news/year-in-review-2020.md
@@ -1,0 +1,45 @@
+---
+layout: default
+title: Year in review – 2020
+nav_order: 2
+has_children: false
+has_toc: true
+parent: About our project
+---
+# Year in review – 2020
+
+*January, 2021*
+
+## Software releases
+
+Our major software goal for the year was updating our core library, liboqs, and our associated sub-projects, to use algorithms from Round 3 of the NIST Post-Quantum Crypto standardization project.  
+
+More details here
+
+### Docker images
+
+Going beyond providing instructions how to build docker images OQS is now actively maintaining several ready-to-run images for an easy start into the topic: These include post-quantum enabled integrations of:
+
+- [OpenSSL/curl](https://hub.docker.com/repository/docker/openquantumsafe/curl)
+- [Apache httpd](https://hub.docker.com/repository/docker/openquantumsafe/httpd)
+- [nginx](https://hub.docker.com/repository/docker/openquantumsafe/nginx)
+- [openssh](https://hub.docker.com/repository/docker/openquantumsafe/openssh)
+- [haproxy](https://hub.docker.com/repository/docker/openquantumsafe/haproxy)
+- [OpenSSL provider](https://hub.docker.com/repository/docker/openquantumsafe/oqs-ossl3)
+
+## Papers and Presentations
+
+## Impact
+
+## Partners
+
+Financial support for OQS in 2020 came from Amazon Web Services and the Canadian Centre for Cyber Security.  Research projects based on OQS were supported by funding from the Natural Sciences and Engineering Research Council of Canada (NSERC).  Microsoft Research donated computation time on Azure. IBM Research and individual contributors provided developer time to move OQS forward.
+
+## Plans for 2021
+
+The efforts on OQS shall be presented at the [PQ NIST conference](https://csrc.nist.gov/Events/2021/third-pqc-standardization-conference) in order to help us better focus our activities.
+
+Thanks to all who have helped OQS advance over the past year! 
+ 
+*Douglas Stebila*<br />
+*Project leader, Open Quantum Safe project*


### PR DESCRIPTION
Update following [this discussion](https://github.com/open-quantum-safe/oqs-provider/pull/20#issuecomment-841600472).

Prior to the NIST workshop it may be good to update the "About" section as it seems dated:

![grafik](https://user-images.githubusercontent.com/57787676/118349672-4dac1100-b552-11eb-8079-01624625c8cc.png)

Could you maybe extend the skeleton for 2020 also added, @dstebila ?