### PR TITLE
Add libssh project to the ssh page.

### DIFF
--- a/applications/ssh.md
+++ b/applications/ssh.md
@@ -62,4 +62,4 @@ See the [README](https://github.com/open-quantum-safe/libssh/blob/OQS-master/REA
 ### Releases
 {: .no_toc }
 
-- [snapshot 2022-01](https://github.com/open-quantum-safe/libssh/releases/tag/OQS-libssh-snapshot-2022-01) aligned with liboqs 0.7.1 (January 6, 2022) <span class="label label-green">current version</span>
+- [snapshot 2022-01](https://github.com/open-quantum-safe/libssh/releases/tag/OQS-libssh-snapshot-2022-01) aligned with liboqs 0.7.1 (January 25, 2022) <span class="label label-green">current version</span>

--- a/index.md
+++ b/index.md
@@ -21,6 +21,7 @@ All of our development takes place on our [Github](https://github.com/open-quant
 
 ## Recent updates
 
+- January 25, 2022: First release of [OQS-libssh](https://github.com/open-quantum-safe/libssh/releases/tag/OQS-libssh-snapshot-2022-01)
 - January 13, 2022: [Year in review 2021](news/year-in-review-2021)
 - January 6, 2022: Release of [OQS-OpenSSL 1.1.1 snapshot 2022-01](https://github.com/open-quantum-safe/openssl/releases/tag/OQS-OpenSSL_1_1_1-stable-snapshot-2022-01), [OQS-BoringSSL snapshot 2022-01](https://github.com/open-quantum-safe/boringssl/releases/tag/OQS-BoringSSL-snapshot-2022-01), [OQS-OpenSSH snapshot 2022-01](https://github.com/open-quantum-safe/openssh/releases/tag/OQS-OpenSSH-snapshot-2022-01), [liboqs-cpp 0.7.1](https://github.com/open-quantum-safe/liboqs-cpp/releases/tag/0.7.1), [liboqs-go 0.7.1](https://github.com/open-quantum-safe/liboqs-go/releases/tag/0.7.1), [liboqs-python 0.7.1](https://github.com/open-quantum-safe/liboqs-python/releases/tag/0.7.1), and [oqs-provider 0.3.0](https://github.com/open-quantum-safe/oqs-provider/releases/tag/0.3.0)
 - December 31, 2021: [VeriSign Inc.](https://verisign.com/) sponsors Open Quantum Safe


### PR DESCRIPTION
Adds the libssh project to the SSH page. Also links to the upcoming [libssh release](https://github.com/open-quantum-safe/libssh/releases/tag/untagged-72a8f9cea8784fe09831) (drafted by @kevinmkane)  