### PR TITLE
OQS-OpenSSH snapshot 2023-10 release

### DIFF
--- a/applications/ssh.md
+++ b/applications/ssh.md
@@ -44,7 +44,8 @@ There also exist [post-quantum-enabled docker images for TLS applications](tls#d
 ### Releases
 {: .no_toc }
 
-- [snapshot 2023-06](https://github.com/open-quantum-safe/openssh/releases/tag/OQS-OpenSSH-snapshot-2023-06) aligned with liboqs 0.8.0 (June 26, 2023) <span class="label label-green">current version</span>
+- [snapshot 2023-10](https://github.com/open-quantum-safe/openssh/releases/tag/OQS-OpenSSH-snapshot-2023-06) aligned with liboqs 0.9.0 (October 21, 2023) <span class="label label-green">current version</span>
+- [snapshot 2023-06](https://github.com/open-quantum-safe/openssh/releases/tag/OQS-OpenSSH-snapshot-2023-06) aligned with liboqs 0.8.0 (June 26, 2023) 
 - [snapshot 2022-08](https://github.com/open-quantum-safe/openssh/releases/tag/OQS-OpenSSH-snapshot-2022-08) aligned with liboqs 0.7.2 (August 23, 2022)
 - [snapshot 2022-01](https://github.com/open-quantum-safe/openssh/releases/tag/OQS-OpenSSH-snapshot-2022-01) aligned with liboqs 0.7.1 (January 6, 2022)
 - [snapshot 2021-08](https://github.com/open-quantum-safe/openssh/releases/tag/OQS-OpenSSH-snapshot-2021-08) aligned with liboqs 0.7.0 (August 11, 2021)

--- a/index.md
+++ b/index.md
@@ -22,6 +22,7 @@ All of our development takes place on our [Github](https://github.com/open-quant
 ## Recent updates
 
 - November 2, 2023, 12-1pm US Eastern time: [liboqs release call on Zoom](https://uwaterloo.zoom.us/j/98288698086)
+- October 21, 2023: Release of [OQS-OpenSSH snapshot 2023-10](https://github.com/open-quantum-safe/openssh/releases/tag/OQS-OpenSSH-snapshot-2023-10)
 - <b>October 12, 2023: Release of [liboqs version 0.9.0](https://github.com/open-quantum-safe/liboqs/releases/tag/0.9.0)</b>
 - July 25, 2023: Release of [oqs-provider 0.5.1](https://github.com/open-quantum-safe/oqs-provider/releases/tag/0.5.1)
 - July 7, 2023: Release of [OQS-OpenSSL 1.1.1 snapshot 2023-07](https://github.com/open-quantum-safe/openssl/releases/tag/OQS-OpenSSL_1_1_1-stable-snapshot-2023-07); note that this is the final release of OQS-OpenSSL 1.1.1


### PR DESCRIPTION
Updated `ssh.md` and `index.md` to record release of OQS-OpenSSH snapshot 2023-10.