### PR TITLE
Update liboqs-python workflow links

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -105,7 +105,10 @@ nav_exclude: true
             <td class="text-center"></td>
             <td class="text-center"></td>
             <td class="text-center"></td>
-            <td class="text-center"><a href="https://github.com/open-quantum-safe/liboqs-python/actions?query=workflow%3A"Continuous+integration"" target="_blank"><img src="https://img.shields.io/github/actions/workflow/status/open-quantum-safe/liboqs-python/python.yml"></a></td>
+            <td class="text-center">
+		    <a href="https://github.com/open-quantum-safe/liboqs-python/actions/workflows/python_detailed.yml" target="_blank"><img src="https://github.com/open-quantum-safe/liboqs-python/actions/workflows/python_detailed.yml/badge.svg"></a>
+		    <a href="https://github.com/open-quantum-safe/liboqs-python/actions/workflows/python_simplified.yml" target="_blank"><img src="https://github.com/open-quantum-safe/liboqs-python/actions/workflows/python_simplified.yml/badge.svg"></a>
+	    </td>
         </tr>
         <tr>
             <td class="text-center"><a href="https://github.com/open-quantum-safe/liboqs-rust">liboqs-rust</a></td>


### PR DESCRIPTION
open-quantum-safe/liboqs-python#80 changed the GitHub Actions configuration for `liboqs-python`. This PR updates the website dashboard to point to the updated workflows. This will fix the red badge on the dashboard for `liboqs-python`.