### PR TITLE
Dashboard update for liboqs: remove CircleCI badge and update milestone

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -21,7 +21,7 @@ nav_exclude: true
     <tbody>
         <tr>
             <td class="text-center"><a href="https://github.com/open-quantum-safe/liboqs">liboqs</a></td>
-            <td class="text-center"><a href="https://app.circleci.com/pipelines/github/open-quantum-safe/liboqs?branch=main" target="_blank"><img src="https://img.shields.io/circleci/build/github/open-quantum-safe/liboqs/main?label=main"></a></td>
+            <td class="text-center"></td>
             <td class="text-center"></td>
             <td class="text-center"><a href="https://travis-ci.com/github/open-quantum-safe/liboqs" target="_blank"><img src="https://api.travis-ci.com/open-quantum-safe/liboqs.svg"></a></td>
             <td class="text-center"><a href="https://github.com/open-quantum-safe/liboqs/actions" target="_blank"><img src="https://github.com/open-quantum-safe/liboqs/actions/workflows/linux.yml/badge.svg"></a>
@@ -139,7 +139,7 @@ nav_exclude: true
             <td class="text-center"><a href="https://github.com/open-quantum-safe/liboqs/pulls" target="_blank"><img src="https://img.shields.io/github/issues-pr/open-quantum-safe/liboqs"></a></td>
             <td class="text-center"><a href="https://github.com/open-quantum-safe/liboqs/issues" target="_blank"><img src="https://img.shields.io/github/issues/open-quantum-safe/liboqs"></a></td>
             <td class="text-center">
-                <a href="https://github.com/open-quantum-safe/liboqs/milestone/23" target="_blank"><img src="https://img.shields.io/github/milestones/progress/open-quantum-safe/liboqs/23"></a>
+                <a href="https://github.com/open-quantum-safe/liboqs/milestone/25" target="_blank"><img src="https://img.shields.io/github/milestones/progress/open-quantum-safe/liboqs/25"></a>
             </td>
             <td class="text-center"><a href="https://github.com/open-quantum-safe/liboqs/commits/main" target="_blank"><img src="https://img.shields.io/github/last-commit/open-quantum-safe/liboqs/main"></a></td>
             <td class="text-center"><a href="https://scorecard.dev/viewer/?uri=github.com/open-quantum-safe/liboqs" target="_blank"><img src="https://api.scorecard.dev/projects/github.com/open-quantum-safe/liboqs/badge"></a></td>


### PR DESCRIPTION
As of open-quantum-safe/liboqs#1849, CircleCI is no longer running for liboqs.