### PR TITLE
Fix child-parent links

### DIFF
--- a/liboqs/algorithms/index.md
+++ b/liboqs/algorithms/index.md
@@ -3,6 +3,7 @@ layout: default
 parent: liboqs
 title: Algorithms
 nav_order: 2
+has_children: true
 ---
 
 # Algorithms in liboqs

--- a/liboqs/api/index.md
+++ b/liboqs/api/index.md
@@ -3,7 +3,7 @@ layout: default
 parent: liboqs
 title: C API documentation
 nav_order: 5
-has_children: false
+has_children: true
 has_toc: false
 ---
 


### PR DESCRIPTION
Fixes #227 by giving the "Algorithms" page the `has_children` attribute. Also fixed for the "C API documentation" page, which also has children with incorrect links.