### PR TITLE
add CROSS

### DIFF
--- a/liboqs/algorithms/index.md
+++ b/liboqs/algorithms/index.md
@@ -38,6 +38,7 @@ has_children: true
 ### NIST PQ signatures on-ramp
 
 - [**MAYO**](sig/mayo)
+- [**CROSS**](sig/cross)
 
 ## Stateful hash-based signature schemes
 

--- a/liboqs/algorithms/sig/cross.md
+++ b/liboqs/algorithms/sig/cross.md
@@ -1,0 +1,8 @@
+---
+layout: default
+parent: Algorithms
+grand_parent: liboqs
+title: CROSS
+---
+
+{% include liboqs/docs/algorithms/sig/cross.md %}


### PR DESCRIPTION
Hi, I noticed that CROSS is missing from the list of supported algorithms on the OQS website. Would this be the correct way to add it?