### PR TITLE
Update list of TSC members

### DIFF
--- a/team/index.md
+++ b/team/index.md
@@ -19,13 +19,14 @@ All our work is done as open source via our [GitHub project](https://github.com/
 The [OQS Technical Steering Committee](https://github.com/open-quantum-safe/tsc) provides oversight of the OQS project. The current members of the Technical Steering Committee are:
 
 - Norm Ashley <span class="text-grey-dk-000">(Cisco)</span>
-- [Michael Baentsch](https://baentsch.ch/)
-- Thomas Bailleux <span class="text-grey-dk-000">(SandboxAQ)</span>
+- [Michael Baentsch](https://baentsch.ch/) <span class="text-grey-dk-000">(independent contributor)</span>
+- Thomas Bailleux <span class="text-grey-dk-000">(independent contributor)</span>
 - [Vlad Gheorghiu](https://vsoftco.github.io) <span class="text-grey-dk-000">(softwareQ Inc.)</span>
 - [Basil Hess](https://research.ibm.com/people/basil-hess) <span class="text-grey-dk-000">(IBM Research)</span>
 - Brian Jarvis <span class="text-grey-dk-000">(AWS)</span>
 - [Christian Paquin](https://www.microsoft.com/en-us/research/people/cpaquin/) <span class="text-grey-dk-000">(Microsoft Research)</span>
 - [Douglas Stebila](https://www.douglas.stebila.ca/research/) <span class="text-grey-dk-000">(University of Waterloo)</span>
+- Spencer Wilson <span class="text-grey-dk-000">(University of Waterloo)</span>
 
 ## Contributors
 


### PR DESCRIPTION
I just noticed that the website's list of TSC members was out of sync with https://github.com/open-quantum-safe/tsc, so I've updated it.