### PR TITLE
External users: add subtlepq under VESvault

### DIFF
--- a/applications/external.md
+++ b/applications/external.md
@@ -43,6 +43,7 @@ liboqs has been used in the following external projects:
 - <a href="https://www.vesvault.com">VESvault</a>:
   - <a href="https://github.com/vesvault/libVES.c">libVES.c</a>: end-to-end encryption / key exchange library in C, with the `ves` CLI — ML-KEM-768 via liboqs as the default key algorithm
   - <a href="https://github.com/vesvault/libVES">libVES.js</a>: the same library for browser and Node (npm `libves`), with liboqs compiled to WebAssembly embedded in the package
+  - <a href="https://github.com/vesvault/subtlepq">subtlepq</a>: post-quantum polyfill for the Web Cryptography API (npm `subtlepq`) — ML-KEM and ML-DSA per the WICG modern-algos draft, powered by a minimal liboqs WebAssembly build (75 KB for all six ML-KEM/ML-DSA parameter sets)
 
 If you're using liboqs, please get in touch and we'll add you to the list!
 


### PR DESCRIPTION
The page invites liboqs users to get in touch — adding a third entry under the existing VESvault item.

[subtlepq](https://github.com/vesvault/subtlepq) (npm `subtlepq`, Apache-2.0) is a polyfill of the WICG Modern Algorithms draft for the Web Cryptography API: ML-KEM and ML-DSA as `crypto.subtle` algorithms, delegating per algorithm to native implementations where they exist. The engine is a dedicated minimal liboqs build (0.16.0, ML-KEM + ML-DSA only) compiled to WebAssembly — 75 KB for all six parameter sets, reproducible byte-identical from the pinned toolchain, validated against NIST ACVP known-answer vectors and byte-parity with Node's native WebCrypto ML-KEM/ML-DSA.

This is a separate liboqs consumer from the libVES.c/libVES.js entries already listed (different build, different API surface).